### PR TITLE
Added HTML doc support

### DIFF
--- a/gotodocumentation.py
+++ b/gotodocumentation.py
@@ -113,6 +113,9 @@ class GotoDocumentationCommand(sublime_plugin.TextCommand):
     def cmake_doc(self, keyword, scope):
         open_url('http://cmake.org/cmake/help/v2.8.8/cmake.html#command:%s' % keyword.lower())
 
+    def html_doc(self, keyword, scope):
+        open_url("https://developer.mozilla.org/en-US/search?q=%s" % keyword)
+
     def run_command(self, command, callback=None, **kwargs):
         if not callback:
             callback = self.display_output


### PR DESCRIPTION
Same search URL as JS docs, because that is still the best documentation for HTML and DOM around.
