### PR TITLE
Processing support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,7 @@ A command to jump to documentation for the current word.
  * Go
  * Smarty
  * Ruby on Rails
+ * Processing
 
 Submit a patch adding more and I'll include it.
 

--- a/gotodocumentation.py
+++ b/gotodocumentation.py
@@ -69,6 +69,9 @@ class GotoDocumentationCommand(sublime_plugin.TextCommand):
                 scope = self.view.scope_name(word.begin()).strip()
                 extracted_scope = scope.rpartition('.')[2]
                 keyword = self.view.substr(word)
+                # This nasty, but I don't know enough Python to express this nicely.
+                if "source.pde" in scope:
+                    extracted_scope = "processing"
                 getattr(self, '%s_doc' % extracted_scope, self.unsupported)(keyword, scope)
 
     def unsupported(self, keyword, scope):
@@ -76,6 +79,9 @@ class GotoDocumentationCommand(sublime_plugin.TextCommand):
 
     def php_doc(self, keyword, scope):
         open_url("http://php.net/%s" % keyword)
+
+    def processing_doc(self, keyword, scope):
+        open_url("http://www.processing.org/reference/%s_" % keyword + ".html")
 
     def rails_doc(self, keyword, scope):
         open_url("http://api.rubyonrails.org/?q=%s" % keyword)


### PR DESCRIPTION
Hello,

I've added support for Processing (http://processing.org/).  I'm using this in combination with https://github.com/b-g/processing-sublime.

I didn't really know how let the plugin pickup the correct scope value, so I kind of hacked my way around it. I'm getting a value similar to the one for PHP (in the style of text.html.basic source.php.embedded.block.html keyword.other.new.php). Is there a better way of doing that? Or is it a matter of setting the correct value somewhere in the https://github.com/b-g/processing-sublime package?

Thanks for all the work, works great.
Bert
