### PR TITLE
Added support for ExpressionEngine

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,7 @@ A command to jump to documentation for the current word.
  * Go
  * Smarty
  * Ruby on Rails
+ * ExpressionEngine
 
 Submit a patch adding more and I'll include it.
 

--- a/gotodocumentation.py
+++ b/gotodocumentation.py
@@ -118,6 +118,9 @@ class GotoDocumentationCommand(sublime_plugin.TextCommand):
     def perl_doc(self, keyword, scope):
         open_url("http://perldoc.perl.org/search.html?q=%s" % keyword)
 
+    def ee_doc(self, keyword, scope):
+        open_url("http://www.google.com/search?site=&source=hp&q=site%%3Ahttp%%3A%%2F%%2Fellislab.com%%2Fexpressionengine%%2Fuser-guide%%2F+%s&oq=site%%3Ahttp%%3A%%2F%%2Fellislab.com%%2Fexpressionengine%%2Fuser-guide%%2F&btnI=1" % keyword)
+
     def run_command(self, command, callback=None, **kwargs):
         if not callback:
             callback = self.panel


### PR DESCRIPTION
Added support for ExpressionEngine documentation.

Unfortunately the EE docs are not normalized with predictable URLs for each keyword. Also unfortunately, the docs have no native search form. They rely on Google to index the docs.

My approach uses google "im feeling lucky" feature to search the EE user guide for
a given keyword, and go directly to the top result. Not perfect but it
will get you to the right page most of the time, and improving this
would likely require EE user guide to be reorganized around predictable
URLs for each keyword.
