### PR TITLE
Add erldocs.com support for erlang.  Works for .erl files.

### DIFF
--- a/gotodocumentation.py
+++ b/gotodocumentation.py
@@ -133,6 +133,11 @@ class GotoDocumentationCommand(sublime_plugin.TextCommand):
     def lua_doc(self, keyword, scope):
         open_url('http://pgl.yoyo.org/luai/i/%s' % keyword)
 
+    def erlang_doc(self, keyword, scope):
+        otp_version = self.view.settings().get("otp_version", "R16B03")
+        url         = 'http://erldocs.com/%(otp_version)s/?search=%(keyword)s' % {'otp_version': otp_version,  'keyword': keyword}
+        open_url(url)
+
     def run_command(self, command, callback=None, **kwargs):
         if not callback:
             callback = self.panel


### PR DESCRIPTION
Just adding erldocs.com support for erlang.

It adds a setting "otp_version" which is required in the URL, it defaults to the latest stable version R16B03.

Cheers
