### PR TITLE
Add BIS ArmA 2/3 script wiki link

### DIFF
--- a/goto_documentation.py
+++ b/goto_documentation.py
@@ -28,6 +28,7 @@ default_docs = {
         "erlang": "http://erldocs.com/R16B03/?search=%(query)s",
         "haskell": "http://hayoo.fh-wedel.de/?query=%(query)s",
         "scala": "http://scalex.org/?q=%(query)s",
+        "sqf": "https://community.bistudio.com/wiki/%(query)s",
         "css": "http://devdocs.io/#q=%(scope)s+%(query)s",
         "scss": "http://devdocs.io/#q=%(scope)s+%(query)s",
         "less": "http://devdocs.io/#q=%(scope)s+%(query)s",


### PR DESCRIPTION
## Please add this line, arma mod-making community will be grateful!

Add BIS ArmA 2/3 script wiki link:
"sqf": "https://community.bistudio.com/wiki/%(query)s",
